### PR TITLE
Enable Generic Data

### DIFF
--- a/src/hdb_response.rs
+++ b/src/hdb_response.rs
@@ -27,12 +27,14 @@ use {HdbError, HdbResult};
 ///
 #[derive(Debug)]
 pub struct HdbResponse {
-    data: Vec<HdbReturnValue>,
-    metadata: Option<Vec<ParameterDescriptor>>,
+    /// the raw return data.
+    pub data: Vec<HdbReturnValue>,
+    /// the metadata.
+    pub metadata: Option<Vec<ParameterDescriptor>>,
 }
 
 impl HdbResponse {
-    /// Returns the number of contained single return values.
+    /// Returns the number of return values.
     pub fn count(&self) -> usize {
         self.data.len()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,8 @@ pub use protocol::parts::resultset::ResultSet;
 pub use protocol::parts::row::Row;
 pub use protocol::parts::server_error::{ServerError, Severity};
 
+
+pub use protocol::parts::parameters::{ParameterRow, Parameters};
 pub use protocol::parts::parameter_descriptor::{
     ParameterBinding, ParameterDescriptor, ParameterDirection,
 };

--- a/src/prepared_statement.rs
+++ b/src/prepared_statement.rs
@@ -35,11 +35,16 @@ impl PreparedStatement {
         self.o_par_md.as_ref()
     }
 
+    /// Descriptors of the input parameters of the prepared statement, if any.
+    pub fn input_parameter_descriptors(&self) -> Option<&Vec<ParameterDescriptor>> {
+        self.o_input_md.as_ref()
+    }
+
     /// Adds a row of ParameterRow for the batch
-    pub fn add_row<T: serde::ser::Serialize>(&mut self, row: ParameterRow) -> HdbResult<()> {
+    pub fn add_row(&mut self, row: ParameterRow) -> HdbResult<()> {
         trace!("PreparedStatement::add_row()");
         match (&(self.o_input_md), &mut (self.o_batch)) {
-            (&Some(ref metadata), &mut Some(ref mut vec)) => {
+            (&Some(ref _metadata), &mut Some(ref mut vec)) => {
                 vec.push(row);
                 Ok(())
             }

--- a/src/prepared_statement.rs
+++ b/src/prepared_statement.rs
@@ -35,6 +35,23 @@ impl PreparedStatement {
         self.o_par_md.as_ref()
     }
 
+    /// Adds a row of ParameterRow for the batch
+    pub fn add_row<T: serde::ser::Serialize>(&mut self, row: ParameterRow) -> HdbResult<()> {
+        trace!("PreparedStatement::add_row()");
+        match (&(self.o_input_md), &mut (self.o_batch)) {
+            (&Some(ref metadata), &mut Some(ref mut vec)) => {
+                vec.push(row);
+                Ok(())
+            }
+            (_, _) => {
+                let s = "no metadata in add_row()";
+                Err(HdbError::Serialization(
+                    SerializationError::StructuralMismatch(s),
+                ))
+            }
+        }
+    }
+
     /// Converts the input into a row of parameters for the batch,
     /// if it is consistent with the metadata.
     pub fn add_batch<T: serde::ser::Serialize>(&mut self, input: &T) -> HdbResult<()> {


### PR DESCRIPTION
This enables custom deserialization of the query result by exposing HdbResponse fields.

For inserting generic data I added the `add_row` method. In `add_batch` the type needs to be known at compile time.
Not sure if creating `ParameterRow` with `HdbValue` is the best way, but it works.