### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/tests/test_015_resultset.rs
+++ b/tests/test_015_resultset.rs
@@ -139,7 +139,7 @@ fn verify_row_ordering(
 
     let stmt = "select * from TEST_ROW_ORDERING order by f1 asc";
 
-    for fs in [10, 100, 1000, 2000].into_iter() {
+    for fs in [10, 100, 1000, 2000].iter() {
         debug!("verify_row_ordering with fetch_size {}", *fs);
         connection.set_fetch_size(*fs).unwrap();
 


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.