### PR TITLE
limit files published to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/hdbconnect/"
 description = "A pure rust driver for SAP HANA(TM)"
 keywords = ["relational", "database", "driver", "serde", "HANA"]
 categories = ["database"]
+include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 all-features = false


### PR DESCRIPTION
By default cargo publish will publish all files in the root folder, this includes e.g.the 1MB tests/blabla.txt

according to `cargo diet` this change will save 72%