### PR TITLE
Fix issue #33

### DIFF
--- a/hdbconnect_async/src/rocket_pool.rs
+++ b/hdbconnect_async/src/rocket_pool.rs
@@ -76,9 +76,9 @@ impl Pool for HanaPoolForRocket {
                 .map_err(|e| HdbError::ConnParams {
                     source: Box::new(e),
                 })?;
-        let connect_config = figment
-            .extract::<ConnectionConfiguration>()
-            .map_err(|_| HdbError::Usage("Incorrect ConnectionConfiguration"))?;
+        let connect_config = figment.extract::<ConnectionConfiguration>().map_err(|_| {
+            HdbError::Usage(std::borrow::Cow::from("Incorrect ConnectionConfiguration"))
+        })?;
         let pool = Self {
             connect_params,
             connect_config,

--- a/hdbconnect_async/tests/test_080_conn_pooling_for_rocket.rs
+++ b/hdbconnect_async/tests/test_080_conn_pooling_for_rocket.rs
@@ -20,6 +20,8 @@ async fn test_080_conn_pooling_for_rocket() -> HdbResult<()> {
 mod inner {
     extern crate serde;
 
+    use std::borrow::Cow;
+
     use hdbconnect_async::{HanaPoolForRocket, HdbError, HdbResult};
     use log::trace;
     use rocket_db_pools::Pool;
@@ -46,9 +48,9 @@ mod inner {
                 0_u8,
                 worker_handle
                     .await
-                    .map_err(|e| HdbError::UsageDetailed(format!(
+                    .map_err(|e| HdbError::Usage(Cow::from(format!(
                         "Joining worker thread failed: {e:?}"
-                    )))?
+                    ))))?
             );
         }
 

--- a/hdbconnect_async/tests/test_081_conn_pooling_for_bb8.rs
+++ b/hdbconnect_async/tests/test_081_conn_pooling_for_bb8.rs
@@ -19,9 +19,9 @@ async fn test_081_conn_pooling_for_bb8() -> HdbResult<()> {
 #[cfg(feature = "bb8_pool")]
 mod inner {
     extern crate serde;
-
     use hdbconnect_async::{ConnectionConfiguration, ConnectionManager, HdbError, HdbResult};
     use log::trace;
+    use std::borrow::Cow;
     use tokio::task::JoinHandle;
 
     const NO_OF_WORKERS: usize = 20;
@@ -51,9 +51,9 @@ mod inner {
                 0_u8,
                 worker_handle
                     .await
-                    .map_err(|e| HdbError::UsageDetailed(format!(
+                    .map_err(|e| HdbError::Usage(Cow::from(format!(
                         "Joining worker thread failed: {e:?}"
-                    )))?
+                    ))))?
             );
         }
 

--- a/hdbconnect_impl/src/a_sync/connection.rs
+++ b/hdbconnect_impl/src/a_sync/connection.rs
@@ -7,7 +7,7 @@ use crate::{
         parts::{ClientContext, ClientContextId, CommandInfo, ConnOptId, OptionValue, ServerError},
         MessageType, Part, Request, ServerUsage,
     },
-    HdbError, HdbResult, IntoConnectParams,
+    usage_err, HdbResult, IntoConnectParams,
 };
 #[cfg(feature = "dist_tx")]
 use dist_tx::a_sync::rm::ResourceManager;
@@ -53,7 +53,7 @@ impl Connection {
     ) -> HdbResult<Self> {
         let params = params.into_connect_params()?;
         if params.password().unsecure().is_empty() {
-            Err(HdbError::Usage("Empty password is not allowed"))
+            Err(usage_err!("Empty password is not allowed"))
         } else {
             Ok(Self {
                 am_conn_core: AmConnCore::try_new_async(params, config).await?,
@@ -141,7 +141,7 @@ impl Connection {
         let vec = &(self.statement(stmt).await?.into_affected_rows()?);
         match vec.len() {
             1 => Ok(vec[0]),
-            _ => Err(HdbError::Usage("number of affected-rows-counts <> 1")),
+            _ => Err(usage_err!("number of affected-rows-counts <> 1")),
         }
     }
 
@@ -618,7 +618,7 @@ impl Connection {
     ///
     /// Errors are unlikely to occur.
     ///
-    /// - `HdbError::ImplDetailed` if the version string was not provided by the database server.
+    /// - `HdbErr::Impl` if the version string was not provided by the database server.
     /// - `HdbError::Poison` if the shared mutex of the inner connection object is poisened.
     pub async fn get_full_version_string(&self) -> String {
         self.am_conn_core

--- a/hdbconnect_impl/src/a_sync/hdb_response.rs
+++ b/hdbconnect_impl/src/a_sync/hdb_response.rs
@@ -1,11 +1,12 @@
 use crate::{
     a_sync::{HdbReturnValue, ResultSet},
     base::InternalReturnValue,
+    impl_err,
     protocol::{
         parts::{ExecutionResult, OutputParameters},
         ReplyType,
     },
-    HdbError, HdbResult,
+    usage_err, HdbError, HdbResult,
 };
 
 /// Represents all possible non-error responses to a database command.
@@ -126,7 +127,7 @@ impl HdbResponse {
                          with these internal return values: {int_return_values:?}"
                         );
                     error!("{}",s);
-                    Err( HdbError::ImplDetailed(s))
+                    Err( impl_err!("{}",s))
                 },
             }
     }
@@ -136,7 +137,7 @@ impl HdbResponse {
             InternalReturnValue::RsState((rs_state, a_rsmd)) => Ok(Self {
                 return_values: vec![HdbReturnValue::ResultSet(ResultSet::new(a_rsmd, rs_state))],
             }),
-            _ => Err(HdbError::Impl(
+            _ => Err(impl_err!(
                 "Wrong InternalReturnValue, a single ResultSet was expected",
             )),
         }
@@ -151,9 +152,7 @@ impl HdbResponse {
                         ExecutionResult::RowsAffected(i) => vec_i.push(i),
                         ExecutionResult::SuccessNoInfo => vec_i.push(0),
                         ExecutionResult::Failure(_) => {
-                            return Err(HdbError::Impl(
-                                "Found unexpected ExecutionResult::Failure",
-                            ));
+                            return Err(impl_err!("Found unexpected ExecutionResult::Failure",));
                         }
                         ExecutionResult::ExtraFailure(_) => unreachable!("not produced by server"),
                     }
@@ -162,7 +161,7 @@ impl HdbResponse {
                     return_values: vec![HdbReturnValue::AffectedRows(vec_i)],
                 })
             }
-            _ => Err(HdbError::Impl(
+            _ => Err(impl_err!(
                 "Wrong InternalReturnValue, a single set of execution results was expected",
             )),
         }
@@ -176,7 +175,7 @@ impl HdbResponse {
                     (Some(er), None) => match er {
                         ExecutionResult::RowsAffected(i) => {
                             if i > 0 {
-                                Err(HdbError::Impl(
+                                Err(impl_err!(
                                     "found an affected-row-count > 0, expected a single Success",
                                 ))
                             } else {
@@ -188,17 +187,17 @@ impl HdbResponse {
                         ExecutionResult::SuccessNoInfo => Ok(Self {
                             return_values: vec![HdbReturnValue::Success],
                         }),
-                        ExecutionResult::Failure(_) => Err(HdbError::Impl(
-                            "Found unexpected returnvalue ExecutionFailed",
-                        )),
+                        ExecutionResult::Failure(_) => {
+                            Err(impl_err!("Found unexpected returnvalue ExecutionFailed",))
+                        }
                         ExecutionResult::ExtraFailure(_) => unreachable!("not produced by server"),
                     },
-                    (_, _) => Err(HdbError::Impl(
+                    (_, _) => Err(impl_err!(
                         "Expected a single Execution Result, found none or multiple ones",
                     )),
                 }
             }
-            _ => Err(HdbError::Impl(
+            _ => Err(impl_err!(
                 "Wrong InternalReturnValue, a single Execution Result was expected",
             )),
         }
@@ -215,7 +214,7 @@ impl HdbResponse {
                             ExecutionResult::RowsAffected(i) => vec_i.push(i),
                             ExecutionResult::SuccessNoInfo => vec_i.push(0),
                             ExecutionResult::Failure(_) => {
-                                return Err(HdbError::Impl(
+                                return Err(impl_err!(
                                     "Found unexpected returnvalue 'ExecutionFailed'",
                                 ));
                             }
@@ -234,9 +233,7 @@ impl HdbResponse {
                     return_values.push(HdbReturnValue::ResultSet(ResultSet::new(a_rsmd, rs_state)));
                 }
                 InternalReturnValue::WriteLobReply(_) => {
-                    return Err(HdbError::Impl(
-                        "found WriteLobReply in multiple_return_values()",
-                    ));
+                    return Err(impl_err!("found WriteLobReply in multiple_return_values()",));
                 }
             }
         }
@@ -403,7 +400,7 @@ impl HdbResponse {
         }
         errmsg.push(']');
         error!("{}", errmsg);
-        HdbError::UsageDetailed(errmsg)
+        usage_err!("{}", errmsg)
     }
 }
 
@@ -416,13 +413,13 @@ fn single(int_return_values: Vec<InternalReturnValue>) -> HdbResult<InternalRetu
         .collect();
 
     match int_return_values.len() {
-        0 => Err(HdbError::Impl(
+        0 => Err(impl_err!(
             "Nothing found, but a single internal return value was expected",
         )),
         1 => Ok(int_return_values.pop().unwrap(/*cannot fail*/)),
-        _ => Err(HdbError::ImplDetailed(format!(
+        _ => Err(impl_err!(
             "single(): Too many InternalReturnValue(s) received: {int_return_values:?}",
-        ))),
+        )),
     }
 }
 

--- a/hdbconnect_impl/src/base/hdb_error.rs
+++ b/hdbconnect_impl/src/base/hdb_error.rs
@@ -116,11 +116,7 @@ pub enum HdbError {
 
     /// Implementation error.
     #[error("Implementation error: {}", _0)]
-    Impl(&'static str),
-
-    /// Implementation error.
-    #[error("Implementation error: {}", _0)]
-    ImplDetailed(String),
+    Impl(std::borrow::Cow<'static, str>),
 
     /// Error occured in thread synchronization.
     // #[cfg(feature = "sync")]
@@ -149,11 +145,7 @@ pub enum HdbError {
 
     /// Error caused by wrong usage.
     #[error("Wrong usage: {}", _0)]
-    Usage(&'static str),
-
-    /// Error caused by wrong usage.
-    #[error("Wrong usage: {}", _0)]
-    UsageDetailed(String),
+    Usage(std::borrow::Cow<'static, str>),
 
     /// Connection is dead
     #[error("Connection is broken")]
@@ -243,4 +235,17 @@ impl<G> From<std::sync::PoisonError<G>> for HdbError {
     fn from(_error: std::sync::PoisonError<G>) -> Self {
         Self::Poison
     }
+}
+
+#[macro_export]
+macro_rules! usage_err {
+    ($($arg:tt)*) => {{
+        crate::HdbError::Usage(std::borrow::Cow::from(format!($($arg)*)))
+    }};
+}
+#[macro_export]
+macro_rules! impl_err {
+    ($($arg:tt)*) => {{
+        crate::HdbError::Impl(std::borrow::Cow::from(format!($($arg)*)))
+    }};
 }

--- a/hdbconnect_impl/src/base/row.rs
+++ b/hdbconnect_impl/src/base/row.rs
@@ -2,7 +2,7 @@ use crate::{
     base::{RsCore, OAM},
     conn::AmConnCore,
     protocol::parts::{HdbValue, ResultSetMetadata},
-    HdbError, HdbResult,
+    usage_err, HdbResult,
 };
 use serde_db::de::DeserializableRow;
 use std::sync::Arc;
@@ -58,7 +58,7 @@ impl Row {
         T: serde::de::Deserialize<'de>,
     {
         self.next_value()
-            .ok_or_else(|| HdbError::Usage("no more value"))?
+            .ok_or_else(|| usage_err!("no more value"))?
             .try_into()
     }
 
@@ -82,11 +82,11 @@ impl Row {
     /// `HdbError::Usage` if the row is empty or has more than one value.
     pub fn into_single_value(mut self) -> HdbResult<HdbValue<'static>> {
         if self.len() > 1 {
-            Err(HdbError::Usage("Row has more than one field"))
+            Err(usage_err!("Row has more than one field"))
         } else {
             Ok(self
                 .next_value()
-                .ok_or_else(|| HdbError::Usage("Row is empty"))?)
+                .ok_or_else(|| usage_err!("Row is empty"))?)
         }
     }
 

--- a/hdbconnect_impl/src/conn/authentication/auth_requests.rs
+++ b/hdbconnect_impl/src/conn/authentication/auth_requests.rs
@@ -1,5 +1,6 @@
 use crate::{
     conn::{authentication::Authenticator, CommandOptions, ConnectionCore},
+    impl_err,
     protocol::{
         parts::{AuthFields, ClientContext, ConnOptId, ConnectOptionsPart, DbConnectInfo},
         MessageType, Part, Reply, ReplyType, Request,
@@ -47,7 +48,7 @@ fn evaluate_first_response(reply: Reply) -> HdbResult<FirstAuthResponse> {
                         server_challenge_data,
                     ))
                 }
-                (_, _, _) => return Err(HdbError::Impl("expected 2 auth_fields")),
+                (_, _, _) => return Err(impl_err!("expected 2 auth_fields")),
             }
         }
         (Some(Part::Error(_vec_server_error)), Some(Part::DbConnectInfo(db_connect_info))) => {
@@ -57,9 +58,9 @@ fn evaluate_first_response(reply: Reply) -> HdbResult<FirstAuthResponse> {
         (Some(Part::Error(mut server_errors)), None) => {
             Err(HdbError::from(server_errors.remove(0)))
         }
-        (p1, p2) => Err(HdbError::ImplDetailed(format!(
-            "Unexpected db response with parts: {p1:?}, {p2:?}",
-        ))),
+        (p1, p2) => Err(impl_err!(
+            "Unexpected db response with parts: {p1:?}, {p2:?}"
+        )),
     };
 
     for part in parts_iter {
@@ -152,7 +153,7 @@ fn evaluate_second_response(
                 (Some(server_proof), Some(method), None) => {
                     chosen_authenticator.evaluate_second_response(&method, &server_proof)?;
                 }
-                (_, _, _) => return Err(HdbError::Impl("Expected 2 authfields")),
+                (_, _, _) => return Err(impl_err!("Expected 2 authfields")),
             },
             _ => warn!("second_auth_request: ignoring unexpected part = {:?}", part),
         }

--- a/hdbconnect_impl/src/conn/authentication/authenticate.rs
+++ b/hdbconnect_impl/src/conn/authentication/authenticate.rs
@@ -8,8 +8,9 @@ use crate::{
         authentication::{Authenticator, FirstAuthResponse, ScramPbkdf2Sha256, ScramSha256},
         ConnectionCore,
     },
+    impl_err,
     protocol::parts::DbConnectInfo,
-    HdbError, HdbResult,
+    HdbResult,
 };
 
 #[must_use]
@@ -44,9 +45,7 @@ pub(crate) fn authenticate_sync(
             let mut authenticator: Box<dyn Authenticator + Send + Sync> = authenticators
                 .into_iter()
                 .find(|authenticator| authenticator.name() == selected)
-                .ok_or_else(|| {
-                    HdbError::Impl("None of the available authenticators was accepted")
-                })?;
+                .ok_or_else(|| impl_err!("None of the available authenticators was accepted"))?;
             // ...and use it for the second request
             second_auth_request_sync(conn_core, &mut *authenticator, &server_challenge, reconnect)?;
             conn_core.set_authenticated();
@@ -79,9 +78,7 @@ pub(crate) async fn authenticate_async(
             let mut authenticator: Box<dyn Authenticator + Send + Sync> = authenticators
                 .into_iter()
                 .find(|authenticator| authenticator.name() == selected)
-                .ok_or_else(|| {
-                    HdbError::Impl("None of the available authenticators was accepted")
-                })?;
+                .ok_or_else(|| impl_err!("None of the available authenticators was accepted"))?;
             // ...and use it for the second request
             second_auth_request_async(conn_core, &mut *authenticator, &server_challenge, reconnect)
                 .await?;

--- a/hdbconnect_impl/src/conn/authentication/authenticator.rs
+++ b/hdbconnect_impl/src/conn/authentication/authenticator.rs
@@ -1,4 +1,4 @@
-use crate::{HdbError, HdbResult};
+use crate::{impl_err, HdbResult};
 use secstr::SecUtf8;
 
 pub(crate) trait Authenticator {
@@ -19,10 +19,10 @@ pub(crate) trait Authenticator {
         if method == self.name().as_bytes() {
             self.verify_server(server_proof)
         } else {
-            Err(HdbError::ImplDetailed(format!(
+            Err(impl_err!(
                 "Wrong method name detected: {}",
                 String::from_utf8_lossy(method)
-            )))
+            ))
         }
     }
 }

--- a/hdbconnect_impl/src/conn/params/connect_params.rs
+++ b/hdbconnect_impl/src/conn/params/connect_params.rs
@@ -1,6 +1,6 @@
 //! Connection parameters
 use super::{cp_url::format_as_url, tls::Tls, Compression};
-use crate::{ConnectParamsBuilder, HdbError, HdbResult, IntoConnectParams};
+use crate::{impl_err, ConnectParamsBuilder, HdbError, HdbResult, IntoConnectParams};
 use rustls::{ClientConfig, RootCertStore};
 use secstr::SecUtf8;
 use serde::de::Deserialize;
@@ -192,7 +192,7 @@ impl ConnectParams {
     #[allow(clippy::too_many_lines)]
     pub(crate) fn rustls_clientconfig(&self) -> HdbResult<(ClientConfig, Vec<String>)> {
         match self.tls {
-            Tls::Off => Err(HdbError::Impl(
+            Tls::Off => Err(impl_err!(
                 "rustls_clientconfig called with Tls::Off - \
                     this should have been prevented earlier",
             )),
@@ -248,9 +248,9 @@ impl ConnectParams {
                                 }
                             }
                             Err(e) => {
-                                return Err(HdbError::ImplDetailed(format!(
+                                return Err(impl_err!(
                                     "Environment variable {env_var} not found, reason: {e}"
-                                )));
+                                ));
                             }
                         },
                         ServerCerts::Directory(trust_anchor_dir) => {
@@ -263,7 +263,8 @@ impl ConnectParams {
                     }
                 }
                 if root_store.is_empty() {
-                    Err(HdbError::ImplDetailed(
+                    Err(impl_err!(
+                        "{}",
                         cert_errors
                             .into_inner()
                             .iter()
@@ -271,7 +272,7 @@ impl ConnectParams {
                                 acc.push_str(x);
                                 acc.push('\n');
                                 acc
-                            }),
+                            },)
                     ))
                 } else {
                     let config = ClientConfig::builder()

--- a/hdbconnect_impl/src/conn/params/connect_params_builder.rs
+++ b/hdbconnect_impl/src/conn/params/connect_params_builder.rs
@@ -1,6 +1,6 @@
 use super::{cp_url::format_as_url, tls::Tls};
 use crate::{
-    conn::Compression, ConnectParams, HdbError, HdbResult, IntoConnectParamsBuilder, ServerCerts,
+    conn::Compression, usage_err, ConnectParams, HdbResult, IntoConnectParamsBuilder, ServerCerts,
 };
 use secstr::SecUtf8;
 
@@ -205,21 +205,19 @@ impl ConnectParamsBuilder {
         let host = self
             .hostname
             .clone()
-            .ok_or_else(|| HdbError::Usage("hostname is missing"))?;
+            .ok_or_else(|| usage_err!("hostname is missing"))?;
 
-        let port = self
-            .port
-            .ok_or_else(|| HdbError::Usage("port is missing"))?;
+        let port = self.port.ok_or_else(|| usage_err!("port is missing"))?;
 
         let dbuser: String = self
             .dbuser
             .clone()
-            .ok_or_else(|| HdbError::Usage("dbuser is missing"))?;
+            .ok_or_else(|| usage_err!("dbuser is missing"))?;
 
         let password = self
             .password
             .clone()
-            .ok_or_else(|| HdbError::Usage("password is missing"))?;
+            .ok_or_else(|| usage_err!("password is missing"))?;
 
         Ok(ConnectParams::new(
             host,

--- a/hdbconnect_impl/src/conn/params/into_connect_params_builder.rs
+++ b/hdbconnect_impl/src/conn/params/into_connect_params_builder.rs
@@ -1,7 +1,7 @@
 use super::cp_url::UrlOpt;
 use crate::{
     url::{HDBSQL, HDBSQLS},
-    ConnectParamsBuilder, HdbError, HdbResult, ServerCerts,
+    usage_err, ConnectParamsBuilder, HdbError, HdbResult, ServerCerts,
 };
 use url::Url;
 
@@ -62,8 +62,9 @@ impl IntoConnectParamsBuilder for Url {
             HDBSQL => false,
             HDBSQLS => true,
             _ => {
-                return Err(HdbError::Usage(
-                    "Unknown protocol, only 'hdbsql' and 'hdbsqls' are supported",
+                return Err(usage_err!(
+                    "Unknown protocol '{}', only 'hdbsql' and 'hdbsqls' are supported",
+                    self.scheme()
                 ));
             }
         };
@@ -103,9 +104,7 @@ impl IntoConnectParamsBuilder for Url {
                     builder.always_uncompressed(true);
                 }
                 None => {
-                    return Err(HdbError::UsageDetailed(format!(
-                        "option '{name}' not supported",
-                    )));
+                    return Err(usage_err!("option '{name}' not supported"));
                 }
             }
         }
@@ -113,7 +112,7 @@ impl IntoConnectParamsBuilder for Url {
         if use_tls {
             if insecure_option {
                 if !server_certs.is_empty() {
-                    return Err(HdbError::Usage(
+                    return Err(usage_err!(
                         "Use either the url-options 'tls_certificate_dir', 'tls_certificate_env', \
                         'tls_certificate_direct' and 'use_mozillas_root_certificates' \
                         to specify the access to the server certificate,\
@@ -124,7 +123,7 @@ impl IntoConnectParamsBuilder for Url {
                 builder.tls_without_server_verification();
             } else {
                 if server_certs.is_empty() {
-                    return Err(HdbError::Usage(
+                    return Err(usage_err!(
                         "Using 'hdbsqls' requires at least one of the url-options \
                         'tls_certificate_dir', 'tls_certificate_env', 'tls_certificate_direct', \
                         'use_mozillas_root_certificates', or 'insecure_omit_server_certificate_check'",
@@ -135,7 +134,7 @@ impl IntoConnectParamsBuilder for Url {
                 }
             }
         } else if insecure_option || !server_certs.is_empty() {
-            return Err(HdbError::Usage(
+            return Err(usage_err!(
                 "Using 'hdbsql' is not possible with any of the url-options \
                     'tls_certificate_dir', 'tls_certificate_env', 'tls_certificate_direct', \
                     'use_mozillas_root_certificates', or 'insecure_omit_server_certificate_check'; \

--- a/hdbconnect_impl/src/protocol/partkind.rs
+++ b/hdbconnect_impl/src/protocol/partkind.rs
@@ -1,4 +1,4 @@
-use crate::{HdbError, HdbResult};
+use crate::{impl_err, HdbResult};
 
 // Here we list all those parts that are or should be implemented by this
 // driver. ABAP related stuff and "reserved" numbers is omitted.
@@ -87,9 +87,7 @@ impl PartKind {
             73 => Ok(Self::SQLReplyOptions),
             74 => Ok(Self::PrintOptions),
 
-            _ => Err(HdbError::ImplDetailed(format!(
-                "PartKind {val} not implemented"
-            ))),
+            _ => Err(impl_err!("PartKind {val} not implemented")),
         }
     }
 }

--- a/hdbconnect_impl/src/protocol/parts.rs
+++ b/hdbconnect_impl/src/protocol/parts.rs
@@ -72,8 +72,9 @@ pub use self::{
 use crate::{
     base::{InternalReturnValue, RsState},
     conn::AmConnCore,
+    impl_err,
     protocol::{part_attributes::FIRST_PACKET, Part, PartAttributes, PartKind, ServerUsage},
-    HdbError, HdbResult,
+    HdbResult,
 };
 use std::sync::Arc;
 
@@ -185,7 +186,7 @@ impl Parts<'static> {
                         );
                         int_return_values.push(InternalReturnValue::RsState((rs, Arc::new(rsmd))));
                     } else {
-                        return Err(HdbError::Impl("Missing required part ResultSetID"));
+                        return Err(impl_err!("Missing required part ResultSetID"));
                     }
                 }
                 Part::ExecutionResults(execution_results) => {
@@ -248,7 +249,7 @@ impl Parts<'static> {
                         );
                         int_return_values.push(InternalReturnValue::RsState((rs, Arc::new(rsmd))));
                     } else {
-                        return Err(HdbError::Impl("Missing required part ResultSetID"));
+                        return Err(impl_err!("Missing required part ResultSetID"));
                     }
                 }
                 Part::ExecutionResults(execution_results) => {

--- a/hdbconnect_impl/src/protocol/parts/db_connect_info.rs
+++ b/hdbconnect_impl/src/protocol/parts/db_connect_info.rs
@@ -1,9 +1,10 @@
 use crate::{
+    impl_err,
     protocol::parts::{
         option_part::{OptionId, OptionPart},
         option_value::OptionValue,
     },
-    {HdbError, HdbResult},
+    HdbResult,
 };
 
 // Part of redirect response to authentication request
@@ -32,11 +33,8 @@ impl DbConnectInfo {
         self.get(&DbConnectInfoId::Host)?.get_string()
     }
     pub fn port(&self) -> HdbResult<u16> {
-        u16::try_from(self.get(&DbConnectInfoId::Port)?.get_int_as_u32()?).map_err(|e| {
-            HdbError::ImplDetailed(format!(
-                "Invalid port number received, can't convert to u16: {e}",
-            ))
-        })
+        u16::try_from(self.get(&DbConnectInfoId::Port)?.get_int_as_u32()?)
+            .map_err(|e| impl_err!("Invalid port number received, can't convert to u16: {e}",))
     }
     pub fn on_correct_database(&self) -> HdbResult<bool> {
         self.get(&DbConnectInfoId::OnCorrectDatabase)?.get_bool()

--- a/hdbconnect_impl/src/protocol/parts/length_indicator.rs
+++ b/hdbconnect_impl/src/protocol/parts/length_indicator.rs
@@ -1,4 +1,4 @@
-use crate::{HdbError, HdbResult};
+use crate::{impl_err, HdbResult};
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
 
 pub(crate) const MAX_1_BYTE_LENGTH: u8 = 245;
@@ -20,7 +20,7 @@ pub(crate) fn emit(l: usize, w: &mut dyn std::io::Write) -> HdbResult<()> {
             w.write_u32::<LittleEndian>(l as u32)?;
         }
         l => {
-            return Err(HdbError::ImplDetailed(format!("Value too big: {l}")));
+            return Err(impl_err!("Value too big: {l}"));
         }
     }
     Ok(())
@@ -32,8 +32,6 @@ pub(crate) fn parse(l8: u8, rdr: &mut dyn std::io::Read) -> HdbResult<usize> {
         LENGTH_INDICATOR_2BYTE => Ok(rdr.read_u16::<LittleEndian>()? as usize),
         LENGTH_INDICATOR_4BYTE => Ok(rdr.read_u32::<LittleEndian>()? as usize),
         LENGTH_INDICATOR_NULL => Ok(rdr.read_u16::<BigEndian>()? as usize),
-        _ => Err(HdbError::ImplDetailed(format!(
-            "Unknown length indicator for AuthField: {l8}",
-        ))),
+        _ => Err(impl_err!("Unknown length indicator for AuthField: {l8}",)),
     }
 }

--- a/hdbconnect_impl/src/protocol/parts/option_part.rs
+++ b/hdbconnect_impl/src/protocol/parts/option_part.rs
@@ -1,5 +1,5 @@
 use crate::protocol::parts::option_value::OptionValue;
-use crate::{HdbError, HdbResult};
+use crate::{impl_err, HdbResult};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 #[cfg(feature = "dist_tx")]
 use std::collections::hash_map::Iter;
@@ -32,9 +32,9 @@ impl<T: OptionId<T> + Debug + Eq + PartialEq + Hash> OptionPart<T> {
     }
 
     pub fn get(&self, id: &T) -> HdbResult<&OptionValue> {
-        self.0.get(id).ok_or_else(|| {
-            HdbError::ImplDetailed(format!("{id:?} not provided in {}", id.part_type()))
-        })
+        self.0
+            .get(id)
+            .ok_or_else(|| impl_err!("{id:?} not provided in {}", id.part_type()))
     }
 
     pub fn len(&self) -> usize {

--- a/hdbconnect_impl/src/protocol/parts/option_value.rs
+++ b/hdbconnect_impl/src/protocol/parts/option_value.rs
@@ -1,6 +1,7 @@
 use crate::{
+    impl_err,
     protocol::{util, util_sync},
-    HdbError, HdbResult,
+    HdbResult,
 };
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -20,14 +21,14 @@ impl OptionValue {
         if let Self::INT(i) = self {
             Ok(*i)
         } else {
-            Err(HdbError::Impl("Not a INT-typed OptionValue"))
+            Err(impl_err!("Not a INT-typed OptionValue"))
         }
     }
     pub fn get_int_as_u32(&self) -> HdbResult<u32> {
         if let Self::INT(i) = self {
             Ok(u32::try_from(*i).unwrap(/*OK*/))
         } else {
-            Err(HdbError::Impl("Not a INT-typed OptionValue"))
+            Err(impl_err!("Not a INT-typed OptionValue"))
         }
     }
 
@@ -35,7 +36,7 @@ impl OptionValue {
     //     if let Self::BIGINT(i) = self {
     //         Ok(*i)
     //     } else {
-    //         Err(HdbError::Impl("Not a BIGINT-typed OptionValue"))
+    //         Err(impl_err!("Not a BIGINT-typed OptionValue"))
     //     }
     // }
 
@@ -43,7 +44,7 @@ impl OptionValue {
     //     if let Self::DOUBLE(d) = self {
     //         Ok(*d)
     //     } else {
-    //         Err(HdbError::Impl("Not a DOUBLE-typed OptionValue"))
+    //         Err(impl_err!("Not a DOUBLE-typed OptionValue"))
     //     }
     // }
 
@@ -51,7 +52,7 @@ impl OptionValue {
         if let Self::BOOLEAN(b) = self {
             Ok(*b)
         } else {
-            Err(HdbError::Impl("Not a BOOLEAN-typed OptionValue"))
+            Err(impl_err!("Not a BOOLEAN-typed OptionValue"))
         }
     }
 
@@ -59,7 +60,7 @@ impl OptionValue {
         if let Self::STRING(ref s) = self {
             Ok(s)
         } else {
-            Err(HdbError::Impl("Not a STRING-typed OptionValue"))
+            Err(impl_err!("Not a STRING-typed OptionValue"))
         }
     }
 
@@ -67,7 +68,7 @@ impl OptionValue {
         if let Self::STRING(s) = self {
             Ok(s)
         } else {
-            Err(HdbError::Impl("Not a STRING-typed OptionValue"))
+            Err(impl_err!("Not a STRING-typed OptionValue"))
         }
     }
 
@@ -75,7 +76,7 @@ impl OptionValue {
     //     if let Self::BSTRING(ref s) = self {
     //         Ok(s)
     //     } else {
-    //         Err(HdbError::Impl("Not a BSTRING-typed OptionValue"))
+    //         Err(impl_err!("Not a BSTRING-typed OptionValue"))
     //     }
     // }
 
@@ -127,9 +128,9 @@ impl OptionValue {
             28 => Ok(Self::BOOLEAN(rdr.read_u8()? > 0)),         // B1
             29 => Ok(Self::STRING(parse_length_and_string(rdr)?)),
             33 => Ok(Self::BSTRING(parse_length_and_binary(rdr)?)),
-            _ => Err(HdbError::ImplDetailed(format!(
+            _ => Err(impl_err!(
                 "OptionValue::parse_value() not implemented for type code {typecode}",
-            ))),
+            )),
         }
     }
 }

--- a/hdbconnect_impl/src/protocol/parts/parameter_descriptor.rs
+++ b/hdbconnect_impl/src/protocol/parts/parameter_descriptor.rs
@@ -1,6 +1,7 @@
 use crate::{
+    impl_err,
     protocol::{util, util_sync},
-    HdbError, HdbResult, HdbValue, TypeId,
+    HdbResult, HdbValue, TypeId,
 };
 use byteorder::{LittleEndian, ReadBytesExt};
 
@@ -183,9 +184,7 @@ impl ParameterDescriptor {
             1 => Ok(ParameterDirection::IN),
             2 => Ok(ParameterDirection::INOUT),
             4 => Ok(ParameterDirection::OUT),
-            _ => Err(HdbError::ImplDetailed(format!(
-                "invalid value for ParameterDirection: {v}"
-            ))),
+            _ => Err(impl_err!("invalid value for ParameterDirection: {v}")),
         }
     }
 

--- a/hdbconnect_impl/src/protocol/parts/parameter_rows.rs
+++ b/hdbconnect_impl/src/protocol/parts/parameter_rows.rs
@@ -1,4 +1,4 @@
-use crate::{protocol::parts::ParameterDescriptors, HdbError, HdbResult, HdbValue};
+use crate::{impl_err, protocol::parts::ParameterDescriptors, HdbResult, HdbValue};
 use serde_db::ser::to_params;
 
 // Implementation of the PARAMETERS part.
@@ -83,7 +83,7 @@ impl<'a> ParameterRow<'a> {
                         .matches_value_type(hdb_value.type_id_for_emit(descriptor.type_id())?)?;
                 }
             } else {
-                return Err(HdbError::Impl("ParameterRow::new(): Not enough metadata"));
+                return Err(impl_err!("ParameterRow::new(): Not enough metadata"));
             }
         }
         Ok(ParameterRow(hdb_parameters))
@@ -96,7 +96,7 @@ impl<'a> ParameterRow<'a> {
             if let Some(descriptor) = in_descriptors.next() {
                 size += value.size(descriptor.type_id())?;
             } else {
-                return Err(HdbError::Impl("ParameterRow::size(): Not enough metadata"));
+                return Err(impl_err!("ParameterRow::size(): Not enough metadata"));
             }
         }
 
@@ -115,7 +115,7 @@ impl<'a> ParameterRow<'a> {
             if let Some(descriptor) = in_descriptors.next() {
                 value.emit(&mut data_pos, descriptor, w)?;
             } else {
-                return Err(HdbError::Impl("ParameterRow::emit(): Not enough metadata"));
+                return Err(impl_err!("ParameterRow::emit(): Not enough metadata"));
             }
         }
         Ok(())

--- a/hdbconnect_impl/src/protocol/parts/partition_information.rs
+++ b/hdbconnect_impl/src/protocol/parts/partition_information.rs
@@ -1,4 +1,4 @@
-use crate::{protocol::util_sync, HdbError, HdbResult};
+use crate::{impl_err, protocol::util_sync, HdbResult};
 use byteorder::{LittleEndian, ReadBytesExt};
 
 #[derive(Debug)]
@@ -22,9 +22,7 @@ impl PartitionMethod {
             0 => Ok(Self::Invalid),
             1 => Ok(Self::RoundRobin),
             2 => Ok(Self::Hash),
-            _ => Err(HdbError::ImplDetailed(format!(
-                "PartitionMethod {val} not implemented",
-            ))),
+            _ => Err(impl_err!("PartitionMethod {val} not implemented",)),
         }
     }
 }
@@ -42,9 +40,7 @@ impl ParameterFunction {
             0 => Ok(Self::Invalid),
             1 => Ok(Self::Year),
             2 => Ok(Self::Month),
-            _ => Err(HdbError::ImplDetailed(format!(
-                "ParameterFunction {val} not implemented",
-            ))),
+            _ => Err(impl_err!("ParameterFunction {val} not implemented",)),
         }
     }
 }

--- a/hdbconnect_impl/src/protocol/parts/type_id.rs
+++ b/hdbconnect_impl/src/protocol/parts/type_id.rs
@@ -1,4 +1,4 @@
-use crate::{HdbError, HdbResult};
+use crate::{impl_err, HdbResult};
 
 /// ID of the value type of a database column or a parameter.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -163,7 +163,7 @@ impl TypeId {
             81 => Self::FIXED8,
             82 => Self::FIXED12,
             // TypeCode_CIPHERTEXT               = 90,  // TODO only for client-side encryption?
-            tc => return Err(HdbError::ImplDetailed(format!("Illegal type code {tc}"))),
+            tc => return Err(impl_err!("Illegal type code {tc}")),
         })
     }
 
@@ -196,9 +196,9 @@ impl TypeId {
             _ => {}
         }
 
-        Err(HdbError::ImplDetailed(format!(
+        Err(impl_err!(
             "value type id {value_type:?} does not match metadata {self:?}",
-        )))
+        ))
     }
 }
 

--- a/hdbconnect_impl/src/protocol/reply_type.rs
+++ b/hdbconnect_impl/src/protocol/reply_type.rs
@@ -1,4 +1,4 @@
-use crate::{HdbError, HdbResult};
+use crate::{impl_err, HdbResult};
 
 // Identifies the nature of the statement or functionality that has been
 // prepared or executed. Is documented as Function Code.
@@ -57,9 +57,7 @@ impl ReplyType {
             25 => Ok(Self::XAControl),
             26 => Ok(Self::XAPrepare),
             27 => Ok(Self::XARecover),
-            _ => Err(HdbError::ImplDetailed(format!(
-                "found unexpected value {val} for ReplyType",
-            ))),
+            _ => Err(impl_err!("found unexpected value {val} for ReplyType")),
         }
     }
 }

--- a/hdbconnect_impl/src/protocol/util.rs
+++ b/hdbconnect_impl/src/protocol/util.rs
@@ -1,5 +1,5 @@
 use crate::types_impl::lob::CharLobSlice;
-use crate::{HdbError, HdbResult};
+use crate::{impl_err, HdbError, HdbResult};
 
 pub(crate) fn io_error<E>(error: E) -> std::io::Error
 where
@@ -90,7 +90,7 @@ pub(crate) fn split_off_orphaned_surrogates(cesu8: Vec<u8>) -> HdbResult<CharLob
             cesu8[3..].to_vec(),
         ),
         Cesu8CharType::NotAStart | Cesu8CharType::TooShort => {
-            return Err(HdbError::Impl("Unexpected value for NCLob"));
+            return Err(impl_err!("Unexpected value for NCLob"));
         }
     };
     let (data, postfix) = cesu8_to_string_and_surrogate(cesu8)?;
@@ -151,9 +151,7 @@ fn cesu8_to_string_and_surrogate(cesu8: Vec<u8>) -> HdbResult<(String, Option<Ve
                 Some(vec![buffer_cesu8[0], buffer_cesu8[1], buffer_cesu8[2]]),
             ))
         }
-        _ => Err(HdbError::ImplDetailed(format!(
-            "Unexpected buffer_cesu8 = {buffer_cesu8:?}",
-        ))),
+        _ => Err(impl_err!("Unexpected buffer_cesu8 = {buffer_cesu8:?}",)),
     }
 }
 

--- a/hdbconnect_impl/src/protocol/util_async.rs
+++ b/hdbconnect_impl/src/protocol/util_async.rs
@@ -1,4 +1,4 @@
-use crate::{HdbError, HdbResult};
+use crate::{impl_err, HdbResult};
 
 pub(crate) async fn skip_bytes<R: std::marker::Unpin + tokio::io::AsyncReadExt>(
     n: usize,
@@ -6,7 +6,7 @@ pub(crate) async fn skip_bytes<R: std::marker::Unpin + tokio::io::AsyncReadExt>(
 ) -> HdbResult<()> {
     const MAXBUFLEN: usize = 16;
     if n > MAXBUFLEN {
-        Err(HdbError::Impl("impl: n > MAXBUFLEN (16)"))
+        Err(impl_err!("impl: n > MAXBUFLEN (16)"))
     } else {
         let mut buffer = [0_u8; MAXBUFLEN];
         let _tmp: usize = rdr.read_exact(&mut buffer[0..n]).await?;

--- a/hdbconnect_impl/src/protocol/util_sync.rs
+++ b/hdbconnect_impl/src/protocol/util_sync.rs
@@ -1,4 +1,4 @@
-use crate::HdbResult;
+use crate::{impl_err, HdbResult};
 
 // Read n bytes, return as Vec<u8>
 pub(crate) fn parse_bytes(len: usize, rdr: &mut dyn std::io::Read) -> HdbResult<Vec<u8>> {
@@ -10,7 +10,7 @@ pub(crate) fn parse_bytes(len: usize, rdr: &mut dyn std::io::Read) -> HdbResult<
 pub(crate) fn skip_bytes(n: usize, rdr: &mut dyn std::io::Read) -> HdbResult<()> {
     const MAXBUFLEN: usize = 16;
     if n > MAXBUFLEN {
-        Err(crate::HdbError::Impl("n > MAXBUFLEN (16)"))
+        Err(impl_err!("n > MAXBUFLEN (16)"))
     } else {
         let mut buffer = [0_u8; MAXBUFLEN];
         Ok(rdr.read_exact(&mut buffer[0..n])?)

--- a/hdbconnect_impl/src/sync/connection.rs
+++ b/hdbconnect_impl/src/sync/connection.rs
@@ -5,7 +5,7 @@ use crate::{
         MessageType, Part, Request, ServerUsage,
     },
     sync::{HdbResponse, PreparedStatement, ResultSet},
-    {HdbError, HdbResult, IntoConnectParams},
+    usage_err, HdbResult, IntoConnectParams,
 };
 use std::time::Duration;
 
@@ -48,7 +48,7 @@ impl Connection {
     ) -> HdbResult<Self> {
         let params = params.into_connect_params()?;
         if params.password().unsecure().is_empty() {
-            Err(HdbError::Usage("Empty password is not allowed"))
+            Err(usage_err!("Empty password is not allowed"))
         } else {
             Ok(Self {
                 am_conn_core: AmConnCore::try_new_sync(params, config)?,
@@ -139,7 +139,7 @@ impl Connection {
         let vec = &(self.statement(stmt)?.into_affected_rows()?);
         match vec.len() {
             1 => Ok(vec[0]),
-            _ => Err(HdbError::Usage("number of affected-rows-counts <> 1")),
+            _ => Err(usage_err!("number of affected-rows-counts <> 1")),
         }
     }
 
@@ -625,7 +625,7 @@ impl Connection {
     ///
     /// Errors are unlikely to occur.
     ///
-    /// - `HdbError::ImplDetailed` if the database name was not provided by the database server.
+    /// - `HdbError::Impl` if the database name was not provided by the database server.
     /// - `HdbError::Poison` if the shared mutex of the inner connection object is poisened.
     pub fn get_database_name(&self) -> HdbResult<String> {
         Ok(self
@@ -642,7 +642,7 @@ impl Connection {
     ///
     /// Errors are unlikely to occur.
     ///
-    /// - `HdbError::ImplDetailed` if the system id was not provided by the database server.
+    /// - `HdbError::Impl` if the system id was not provided by the database server.
     /// - `HdbError::Poison` if the shared mutex of the inner connection object is poisened.
     pub fn get_system_id(&self) -> HdbResult<String> {
         Ok(self
@@ -695,7 +695,7 @@ impl Connection {
     ///
     /// Errors are unlikely to occur.
     ///
-    /// - `HdbError::ImplDetailed` if the version string was not provided by the database server.
+    /// - `HdbError::Impl` if the version string was not provided by the database server.
     /// - `HdbError::Poison` if the shared mutex of the inner connection object is poisened.
     pub fn get_full_version_string(&self) -> HdbResult<String> {
         Ok(self

--- a/hdbconnect_impl/src/types_impl/daydate.rs
+++ b/hdbconnect_impl/src/types_impl/daydate.rs
@@ -1,4 +1,4 @@
-use crate::{HdbError, HdbResult, HdbValue};
+use crate::{impl_err, HdbResult, HdbValue};
 use byteorder::{LittleEndian, ReadBytesExt};
 
 const NULL_REPRESENTATION: i32 = 3_652_062;
@@ -85,9 +85,7 @@ pub(crate) fn parse_daydate(
         if nullable {
             Ok(HdbValue::NULL)
         } else {
-            Err(HdbError::Impl(
-                "found NULL value for NOT NULL DAYDATE column",
-            ))
+            Err(impl_err!("found NULL value for NOT NULL DAYDATE column",))
         }
     } else {
         Ok(HdbValue::DAYDATE(DayDate::new(i)))

--- a/hdbconnect_impl/src/types_impl/lob/blob_handle.rs
+++ b/hdbconnect_impl/src/types_impl/lob/blob_handle.rs
@@ -1,4 +1,7 @@
 #[cfg(feature = "async")]
+use crate::usage_err;
+
+#[cfg(feature = "async")]
 use super::fetch::fetch_a_lob_chunk_async;
 #[cfg(feature = "sync")]
 use super::fetch::fetch_a_lob_chunk_sync;
@@ -6,8 +9,9 @@ use super::LobBuf;
 use crate::{
     base::{RsCore, XMutexed, OAM},
     conn::AmConnCore,
+    impl_err,
     protocol::{util, ServerUsage},
-    HdbError, HdbResult,
+    HdbResult,
 };
 use debug_ignore::DebugIgnore;
 use std::{
@@ -96,7 +100,7 @@ impl BLobHandle {
     #[cfg(feature = "sync")]
     fn fetch_next_chunk_sync(&mut self) -> HdbResult<usize> {
         if self.is_data_complete {
-            return Err(HdbError::Impl("fetch_next_chunk(): already complete"));
+            return Err(impl_err!("fetch_next_chunk(): already complete"));
         }
 
         let read_length = std::cmp::min(
@@ -138,7 +142,7 @@ impl BLobHandle {
     #[cfg(feature = "async")]
     async fn fetch_next_chunk_async(&mut self) -> HdbResult<()> {
         if self.is_data_complete {
-            return Err(HdbError::Impl("fetch_next_chunk(): already complete"));
+            return Err(impl_err!("fetch_next_chunk(): already complete"));
         }
 
         let read_length = std::cmp::min(
@@ -211,8 +215,8 @@ impl BLobHandle {
         if self.is_data_complete {
             Ok(self.data.0.into_inner())
         } else {
-            Err(HdbError::Usage(
-                "Can't convert BLob that is not not completely loaded",
+            Err(usage_err!(
+                "Can't convert BLob that is not not completely loaded"
             ))
         }
     }

--- a/hdbconnect_impl/src/types_impl/lob/clob_handle.rs
+++ b/hdbconnect_impl/src/types_impl/lob/clob_handle.rs
@@ -6,8 +6,9 @@ use super::{CharLobSlice, LobBuf, UTF_BUFFER_SIZE};
 use crate::{
     base::{RsCore, OAM},
     conn::AmConnCore,
+    impl_err,
     protocol::util,
-    {HdbError, HdbResult, ServerUsage},
+    usage_err, HdbResult, ServerUsage,
 };
 use debug_ignore::DebugIgnore;
 use std::io::{Cursor, Write};
@@ -110,7 +111,7 @@ impl CLobHandle {
     #[allow(clippy::cast_possible_truncation)]
     fn fetch_next_chunk_sync(&mut self) -> HdbResult<()> {
         if self.is_data_complete {
-            return Err(HdbError::Impl("fetch_next_chunk_sync(): already complete"));
+            return Err(impl_err!("fetch_next_chunk_sync(): already complete"));
         }
 
         let read_length = std::cmp::min(
@@ -152,7 +153,7 @@ impl CLobHandle {
     #[allow(clippy::cast_possible_truncation)]
     pub async fn fetch_next_chunk_async(&mut self) -> HdbResult<()> {
         if self.is_data_complete {
-            return Err(HdbError::Impl("fetch_next_chunk_async(): already complete"));
+            return Err(impl_err!("fetch_next_chunk_async(): already complete"));
         }
 
         let read_length = std::cmp::min(
@@ -217,8 +218,8 @@ impl CLobHandle {
         if self.is_data_complete {
             Ok(util::string_from_cesu8(self.cesu8.0.into_inner())?)
         } else {
-            Err(HdbError::Usage(
-                "CLob must be loaded completely before 'into_string' can be called",
+            Err(usage_err!(
+                "CLob must be loaded completely before 'into_string' can be called"
             ))
         }
     }

--- a/hdbconnect_impl/src/types_impl/lob/fetch.rs
+++ b/hdbconnect_impl/src/types_impl/lob/fetch.rs
@@ -1,10 +1,11 @@
 use crate::{
     conn::{AmConnCore, CommandOptions},
+    impl_err,
     protocol::{
         parts::{ReadLobReply, ReadLobRequest},
         MessageType, Part, ReplyType, Request, ServerUsage,
     },
-    HdbError, HdbResult,
+    HdbResult,
 };
 
 // Note that requested_length and offset count either bytes (BLOB, CLOB), or 1-2-3-chars (NCLOB)
@@ -30,7 +31,7 @@ pub(crate) fn fetch_a_lob_chunk_sync(
         match part {
             Part::ReadLobReply(read_lob_reply) => {
                 if *read_lob_reply.locator_id() != locator_id {
-                    return Err(HdbError::Impl("locator ids do not match"));
+                    return Err(impl_err!("locator ids do not match"));
                 }
                 o_read_lob_reply = Some(read_lob_reply);
             }
@@ -49,7 +50,7 @@ pub(crate) fn fetch_a_lob_chunk_sync(
 
     o_read_lob_reply
         .map(ReadLobReply::into_data_and_last)
-        .ok_or_else(|| HdbError::Impl("fetching a lob chunk failed"))
+        .ok_or_else(|| impl_err!("fetching a lob chunk failed"))
 }
 
 // Note that requested_length and offset count either bytes (BLOB, CLOB), or 1-2-3-chars (NCLOB)
@@ -75,7 +76,7 @@ pub(crate) async fn fetch_a_lob_chunk_async(
         match part {
             Part::ReadLobReply(read_lob_reply) => {
                 if *read_lob_reply.locator_id() != locator_id {
-                    return Err(HdbError::Impl("locator ids do not match"));
+                    return Err(impl_err!("locator ids do not match"));
                 }
                 o_read_lob_reply = Some(read_lob_reply);
             }
@@ -94,5 +95,5 @@ pub(crate) async fn fetch_a_lob_chunk_async(
 
     o_read_lob_reply
         .map(ReadLobReply::into_data_and_last)
-        .ok_or_else(|| HdbError::Impl("fetching a lob chunk failed"))
+        .ok_or_else(|| impl_err!("fetching a lob chunk failed"))
 }

--- a/hdbconnect_impl/src/types_impl/lob/lob_writer_util.rs
+++ b/hdbconnect_impl/src/types_impl/lob/lob_writer_util.rs
@@ -1,4 +1,5 @@
-use crate::{HdbError, HdbResult};
+use crate::{impl_err, HdbResult};
+
 pub(crate) enum LobWriteMode {
     //Offset(i64),
     Append,
@@ -28,7 +29,7 @@ pub(crate) fn get_utf8_tail_len(bytes: &[u8]) -> HdbResult<usize> {
                     });
                 }
             }
-            Err(HdbError::Impl("no valid utf8 cutoff point found!"))
+            Err(impl_err!("no valid utf8 cutoff point found!"))
         }
     }
 }

--- a/hdbconnect_impl/src/types_impl/lob/nclob_handle.rs
+++ b/hdbconnect_impl/src/types_impl/lob/nclob_handle.rs
@@ -8,8 +8,9 @@ use super::{CharLobSlice, LobBuf, UTF_BUFFER_SIZE};
 use crate::{
     base::{RsCore, OAM},
     conn::AmConnCore,
+    impl_err,
     protocol::util,
-    {HdbError, HdbResult, ServerUsage},
+    usage_err, HdbResult, ServerUsage,
 };
 use debug_ignore::DebugIgnore;
 use std::io::{Cursor, Write};
@@ -121,7 +122,7 @@ impl NCLobHandle {
     #[allow(clippy::cast_possible_truncation)]
     fn fetch_next_chunk_sync(&mut self) -> HdbResult<()> {
         if self.is_data_complete {
-            return Err(HdbError::Impl("fetch_next_chunk_sync: already complete"));
+            return Err(impl_err!("fetch_next_chunk_sync: already complete"));
         }
 
         let read_length = std::cmp::min(
@@ -165,7 +166,7 @@ impl NCLobHandle {
     #[allow(clippy::cast_possible_truncation)]
     async fn fetch_next_chunk_async(&mut self) -> HdbResult<()> {
         if self.is_data_complete {
-            return Err(HdbError::Impl("fetch_next_chunk_async(): already complete"));
+            return Err(impl_err!("fetch_next_chunk_async(): already complete"));
         }
 
         let read_length = std::cmp::min(
@@ -231,7 +232,7 @@ impl NCLobHandle {
         if self.is_data_complete {
             Ok(util::string_from_cesu8(self.cesu8.0.into_inner())?)
         } else {
-            Err(HdbError::Usage(
+            Err(usage_err!(
                 "NCLob must be loaded completely before 'into_string' can be called",
             ))
         }

--- a/hdbconnect_impl/src/types_impl/lob/wire.rs
+++ b/hdbconnect_impl/src/types_impl/lob/wire.rs
@@ -1,8 +1,9 @@
 use crate::{
     base::{RsCore, OAM},
     conn::AmConnCore,
+    impl_err,
     protocol::{parts::TypeId, util_sync},
-    HdbError, HdbResult, HdbValue,
+    HdbResult, HdbValue,
 };
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -19,7 +20,7 @@ pub(crate) fn parse_blob_sync(
         if nullable {
             Ok(HdbValue::NULL)
         } else {
-            Err(HdbError::Impl("found null value for not-null BLOB column"))
+            Err(impl_err!("found null value for not-null BLOB column"))
         }
     } else {
         let (_, length, locator_id, data) = parse_lob_2(rdr, is_data_included)?;
@@ -47,7 +48,7 @@ pub(crate) async fn parse_blob_async(
         if nullable {
             Ok(HdbValue::NULL)
         } else {
-            Err(HdbError::Impl("found null value for not-null BLOB column"))
+            Err(impl_err!("found null value for not-null BLOB column"))
         }
     } else {
         let (_, length, locator_id, data) = parse_lob_2(rdr, is_data_included)?;
@@ -75,7 +76,7 @@ pub(crate) fn parse_clob_sync(
         if nullable {
             Ok(HdbValue::NULL)
         } else {
-            Err(HdbError::Impl("found null value for not-null CLOB column"))
+            Err(impl_err!("found null value for not-null CLOB column"))
         }
     } else {
         let (char_length, byte_length, locator_id, data) = parse_lob_2(rdr, is_data_included)?;
@@ -104,7 +105,7 @@ pub(crate) async fn parse_clob_async(
         if nullable {
             Ok(HdbValue::NULL)
         } else {
-            Err(HdbError::Impl("found null value for not-null CLOB column"))
+            Err(impl_err!("found null value for not-null CLOB column"))
         }
     } else {
         let (char_length, byte_length, locator_id, data) = parse_lob_2(rdr, is_data_included)?;
@@ -134,7 +135,7 @@ pub(crate) fn parse_nclob_sync(
         if nullable {
             Ok(HdbValue::NULL)
         } else {
-            Err(HdbError::Impl("found null value for not-null NCLOB column"))
+            Err(impl_err!("found null value for not-null NCLOB column"))
         }
     } else {
         let (char_length, byte_length, locator_id, data) = parse_lob_2(rdr, is_data_included)?;
@@ -148,7 +149,7 @@ pub(crate) fn parse_nclob_sync(
                 locator_id,
                 data,
             )),
-            _ => return Err(HdbError::Impl("unexpected type id for nclob")),
+            _ => return Err(impl_err!("unexpected type id for nclob")),
         })
     }
 }
@@ -167,7 +168,7 @@ pub(crate) async fn parse_nclob_async(
         if nullable {
             Ok(HdbValue::NULL)
         } else {
-            Err(HdbError::Impl("found null value for not-null NCLOB column"))
+            Err(impl_err!("found null value for not-null NCLOB column"))
         }
     } else {
         let (char_length, byte_length, locator_id, data) = parse_lob_2(rdr, is_data_included)?;
@@ -181,7 +182,7 @@ pub(crate) async fn parse_nclob_async(
                 locator_id,
                 data,
             )),
-            _ => return Err(HdbError::Impl("unexpected type id for nclob")),
+            _ => return Err(impl_err!("unexpected type id for nclob")),
         })
     }
 }

--- a/hdbconnect_impl/src/types_impl/longdate.rs
+++ b/hdbconnect_impl/src/types_impl/longdate.rs
@@ -1,4 +1,4 @@
-use crate::{HdbError, HdbResult, HdbValue};
+use crate::{impl_err, HdbResult, HdbValue};
 use byteorder::{LittleEndian, ReadBytesExt};
 
 const NULL_REPRESENTATION: i64 = 3_155_380_704_000_000_001;
@@ -102,9 +102,7 @@ pub(crate) fn parse_longdate(
         if nullable {
             Ok(HdbValue::NULL)
         } else {
-            Err(HdbError::Impl(
-                "found NULL value for NOT NULL LONGDATE column",
-            ))
+            Err(impl_err!("found NULL value for NOT NULL LONGDATE column",))
         }
     } else {
         Ok(HdbValue::LONGDATE(LongDate::new(i)))

--- a/hdbconnect_impl/src/types_impl/seconddate.rs
+++ b/hdbconnect_impl/src/types_impl/seconddate.rs
@@ -1,4 +1,4 @@
-use crate::{HdbError, HdbResult, HdbValue};
+use crate::{impl_err, HdbResult, HdbValue};
 use byteorder::{LittleEndian, ReadBytesExt};
 
 const NULL_REPRESENTATION: i64 = 315_538_070_401;
@@ -102,9 +102,7 @@ pub(crate) fn parse_seconddate(
         if nullable {
             Ok(HdbValue::NULL)
         } else {
-            Err(HdbError::Impl(
-                "found NULL value for NOT NULL SECONDDATE column",
-            ))
+            Err(impl_err!("found NULL value for NOT NULL SECONDDATE column",))
         }
     } else {
         Ok(HdbValue::SECONDDATE(SecondDate::new(i)))

--- a/hdbconnect_impl/src/types_impl/secondtime.rs
+++ b/hdbconnect_impl/src/types_impl/secondtime.rs
@@ -1,4 +1,4 @@
-use crate::{HdbError, HdbResult, HdbValue};
+use crate::{impl_err, HdbResult, HdbValue};
 use byteorder::{LittleEndian, ReadBytesExt};
 
 const NULL_REPRESENTATION: i32 = 86_402;
@@ -63,9 +63,7 @@ pub(crate) fn parse_secondtime(
         if nullable {
             Ok(HdbValue::NULL)
         } else {
-            Err(HdbError::Impl(
-                "found NULL value for NOT NULL SECONDTIME column",
-            ))
+            Err(impl_err!("found NULL value for NOT NULL SECONDTIME column",))
         }
     } else {
         Ok(HdbValue::SECONDTIME(SecondTime::new(i)))

--- a/hdbconnect_impl/src/types_impl/wire_decimal.rs
+++ b/hdbconnect_impl/src/types_impl/wire_decimal.rs
@@ -1,4 +1,4 @@
-use crate::{HdbError, HdbResult, HdbValue};
+use crate::{impl_err, HdbResult, HdbValue};
 use bigdecimal::{BigDecimal, Zero};
 use byteorder::{ByteOrder, LittleEndian};
 use num_bigint::{BigInt, Sign};
@@ -27,7 +27,7 @@ pub(crate) fn wire_decimal_to_hdbvalue(
         if nullable {
             Ok(HdbValue::NULL)
         } else {
-            Err(HdbError::Impl("received null value for not-null column"))
+            Err(impl_err!("received null value for not-null column"))
         }
     } else {
         let is_negative = (raw[15] & 0b_1000_0000_u8) != 0;

--- a/hdbconnect_impl/src/xa_impl/async_c_resource_manager.rs
+++ b/hdbconnect_impl/src/xa_impl/async_c_resource_manager.rs
@@ -1,7 +1,7 @@
 use crate::{
     conn::{AmConnCore, CommandOptions},
     protocol::{parts::XatOptions, MessageType, Part, PartKind, Reply, Request},
-    HdbError, HdbResult,
+    usage_err, HdbError, HdbResult,
 };
 use async_trait::async_trait;
 #[cfg(feature = "dist_tx")]
@@ -168,7 +168,7 @@ impl HdbCResourceManager {
             .configuration()
             .is_auto_commit()
         {
-            return Err(HdbError::Usage(
+            return Err(usage_err!(
                 "xa_*() not possible, connection is set to auto_commit",
             ));
         }

--- a/hdbconnect_impl/src/xa_impl/sync_c_resource_manager.rs
+++ b/hdbconnect_impl/src/xa_impl/sync_c_resource_manager.rs
@@ -1,7 +1,7 @@
 use crate::{
     conn::{AmConnCore, CommandOptions},
     protocol::{parts::XatOptions, MessageType, Part, PartKind, Reply, Request},
-    HdbError, HdbResult,
+    usage_err, HdbError, HdbResult,
 };
 use dist_tx::{
     sync::rm::{CResourceManager, CRmWrapper},
@@ -160,7 +160,7 @@ impl HdbCResourceManager {
             .configuration()
             .is_auto_commit()
         {
-            return Err(HdbError::Usage(
+            return Err(usage_err!(
                 "xa_*() not possible, connection is set to auto_commit",
             ));
         }


### PR DESCRIPTION
This change removes the duplications given by `HdbError::Usage` and `HdbError::UsageDetailed`, and by `HdbError::Impl` and `HdbError::ImplDetailed`.
The duplication was introduced because in many cases the error was ideally "fed" with a &static str, while others needed a real String.
This is now resolved by defining `HdbError::Usage` and `HdbError::Impl` as wrappers of `Cow`, and be introducing macros for creating these error variants like with format!.
